### PR TITLE
Fix: Use Union for UseItem

### DIFF
--- a/src/common/core/level/item.ts
+++ b/src/common/core/level/item.ts
@@ -5,9 +5,14 @@ import { ParticleItem } from '../particle/item'
 import { SRL } from '../resource/srl'
 import { SkinItem } from '../skin/item'
 
-export type UseItem<T> = {
-    useDefault: boolean
-    item?: T
+export type UseItem<T> = UseItemTrue<T> | UseItemFalse
+
+export type UseItemTrue<T>  ={
+    useDefault: true
+    item: T
+}
+export type UseItemFalse  ={
+    useDefault: false
 }
 
 export type LevelItem = {

--- a/src/common/core/level/item.ts
+++ b/src/common/core/level/item.ts
@@ -7,10 +7,10 @@ import { SkinItem } from '../skin/item'
 
 export type UseItem<T> = UseItemTrue | UseItemFalse<T>
 
-export type UseItemTrue  ={
+export type UseItemTrue = {
     useDefault: true
 }
-export type UseItemFalse<T>  ={
+export type UseItemFalse<T> = {
     useDefault: false
     item: T
 }

--- a/src/common/core/level/item.ts
+++ b/src/common/core/level/item.ts
@@ -5,14 +5,14 @@ import { ParticleItem } from '../particle/item'
 import { SRL } from '../resource/srl'
 import { SkinItem } from '../skin/item'
 
-export type UseItem<T> = UseItemTrue<T> | UseItemFalse
+export type UseItem<T> = UseItemTrue | UseItemFalse<T>
 
-export type UseItemTrue<T>  ={
+export type UseItemTrue  ={
     useDefault: true
-    item: T
 }
-export type UseItemFalse  ={
+export type UseItemFalse<T>  ={
     useDefault: false
+    item: T
 }
 
 export type LevelItem = {


### PR DESCRIPTION
This PR Fixes the type resolving problem of UseItem.

```ts
// before
ui = level.useSkin
if (ui.useDefault) {
  ui.item // => item? because TS doesn't know the relation between UseItem.useDefault and UseItem.item
} else {
  ui.item // => item?
}
```

```ts
// after
ui = level.useSkin
if (ui.useDefault) {
  ui.item // => error!
} else {
  ui.item // => item
}
```
